### PR TITLE
string conversion fix on tokenize functrion

### DIFF
--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -66,6 +66,8 @@ exports.tokenize = function (str) {
   var token, captures, ignore, input,
       indents = lastIndents = 0,
       stack = []
+  if (typeof str == 'String')
+    str = str.toString();
   while (str.length) {
     for (var i = 0, len = tokens.length; i < len; ++i)
       if (captures = tokens[i][1].exec(str)) {


### PR DESCRIPTION
I encountered an error when trying to use js-yaml.
It generates an error on the tokenize function when parsing non-string objects.
I've added a forced string conversion which fixes the problem.
Feel free to pull if you want this.
