### PR TITLE
Fix for Issue 15

### DIFF
--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -238,8 +238,10 @@ Parser.prototype.parse = function() {
     case 'int':
       return parseInt(this.advanceValue())
     case 'true':
-      return true
+      this.advance();
+      return true;
     case 'false':
+      this.advance();
       return false
   }
 }


### PR DESCRIPTION
By adding a call to advance for both boolean values, the parsing continues correctly.
