### PR TITLE
Literal support

### DIFF
--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -225,7 +225,7 @@ Parser.prototype.parse = function() {
   switch (this.peek()[0]) {
     case 'doc':
       return this.parseDoc()
-    case 'literal':
+    case '|':
       return this.parseLiteral()
     case '-':
       return this.parseList()


### PR DESCRIPTION
Hi TJ,

I've added support for YAML literals. I wasn't able to get JSpec to work but made some test logic to verify it works:

yaml_test.js: https://gist.github.com/866171
test.yml: https://gist.github.com/866169

Cheers,
Mike
