### PR TITLE
Boolean tokens stops the parser

### DIFF
--- a/examples/boolean.yaml
+++ b/examples/boolean.yaml
@@ -1,0 +1,7 @@
+---
+  title: Some Title
+  falseme: I can see this
+  what: no
+  say: yes
+  trueme: found
+  hope: to see this

--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -37,8 +37,8 @@ var tokens = [
   ['comment', /^#[^\n]*/],
   ['indent', /^\n( *)/],
   ['space', /^ +/],
-  ['true', /^(enabled|true|yes|on)/],
-  ['false', /^(disabled|false|no|off)/],
+  ['true', /^\b(enabled|true|yes|on)\b/],
+  ['false', /^\b(disabled|false|no|off)\b/],
   ['string', /^"(.*?)"/],
   ['string', /^'(.*?)'/],
   ['timestamp', /^((\d{4})-(\d\d?)-(\d\d?)(?:(?:[ \t]+)(\d\d?):(\d\d)(?::(\d\d))?)?)/],
@@ -53,7 +53,7 @@ var tokens = [
   ['-', /^\-/],
   [':', /^[:]/],
   ['string', /^(?![^:\n\s]*:[^\/]{2})(([^:,\]\}\n\s]|(?!\n)\s(?!\s*?\n)|:\/\/|,(?=[^\n]*\s*[^\]\}\s\n]\s*\n)|[\]\}](?=[^\n]*\s*[^\]\}\s\n]\s*\n))*)(?=[,:\]\}\s\n]|$)/], 
-  ['id', /^([\w ]+)/],
+  ['id', /^([\w ]+)/]
 ]
 
 /**
@@ -241,9 +241,9 @@ Parser.prototype.parse = function() {
     case 'int':
       return parseInt(this.advanceValue())
     case 'true':
-      return true
+      this.advanceValue(); return true
     case 'false':
-      return false
+      this.advanceValue(); return false
   }
 }
 


### PR DESCRIPTION
If a boolean token is found, the parse doesn't advance and returns.

Also, if an id starts with a yaml boolean (i.e. nomore, yesman, enabledFeature) the parser also stops advancing and returns the parsed tokens until that point in time.

see examples/boolean.yaml

badly need unit tests...
