### PR TITLE
Handle object lists that start on the same line as the -

### DIFF
--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -69,6 +69,9 @@ exports.tokenize = function (str) {
   var token, captures, ignore, input,
       indents = lastIndents = 0,
       stack = []
+
+  str = str.replace(/\n( *)-( [\w ]+:)/g, '\n$1-\n$1 $2')
+
   while (str.length) {
     for (var i = 0, len = tokens.length; i < len; ++i)
       if (captures = tokens[i][1].exec(str)) {
@@ -77,15 +80,6 @@ exports.tokenize = function (str) {
         switch (token[0]) {
           case 'comment':
             ignore = true
-            break
-          case '-':
-            if(str.match(/^ [\w ]+:/)) {
-              var sp='\n '
-              for(var j=0; j<indents; j++) {
-                sp += '  '
-              }
-              str = sp + str
-            }
             break
           case 'indent':
             lastIndents = indents


### PR DESCRIPTION
yaml.js has trouble parsing files that look like this one: http://ua-parser.googlecode.com/svn/trunk/resources/user_agent_parser.yaml

The problem appears to be sections like this:

```
  - regex: '^(Opera)/(\d+)\.(\d+) \(Nintendo Wii'
    family_replacement: 'Wii'
```

This needs to translate into an object with keys `regex` and `family_replacement`, with the object inside a list.

The problem is that yaml.js sees a different indent for the two lines and gets confused.

This patch changes the input to look like this:

```
  -
    regex: '^(Opera)/(\d+)\.(\d+) \(Nintendo Wii'
    family_replacement: 'Wii'
```

Which yaml.js is much happier with.

We could probably do much more to make the parser more intelligent, but in this case just canonicalizing the input is simpler and may be faster.
