### PR TITLE
Set milliseconds to 0

### DIFF
--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -360,6 +360,7 @@ Parser.prototype.parseTimestamp = function() {
   date.setUTCHours(hour)
   date.setUTCMinutes(min)
   date.setUTCSeconds(sec)
+  date.setUTCMilliseconds(0)
   return date
 }
 


### PR DESCRIPTION
Milliseconds in timestamps are copied from current time but should be 0
