### PR TITLE
some fixes and evalFileSync function, that is simple and usefull

### DIFF
--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -5,6 +5,8 @@
  * Version triplet.
  */
 
+var fs = require('fs');
+
 exports.version = '0.2.2'
 
 // --- Helpers
@@ -382,5 +384,18 @@ Parser.prototype.parseTimestamp = function() {
  */
 
 exports.eval = function(str) {
-  return (new Parser(exports.tokenize(str))).parse()
-}
+  return (new Parser(exports.tokenize((str.toString() + '\n').replace(/\r/g, '').replace(/\n\s*\n/g, '\n')))).parse();
+};
+
+/**
+ * Evaluates a file synchronous
+ *
+ * @param  {filePath}
+ * @param  {encoding}
+ * @return {mixed}
+ * @api public
+ */
+
+exports.evalFileSync = function(filePath, encoding){
+    return exports.eval(fs.readFileSync(filePath, encoding));
+};


### PR DESCRIPTION
fixed: '\r\n' and '\n\r' leads to an error
fixed: empty lines should be ignored
fixed: last line missed if no '\n' at it's end
added: evalFileSync function
