### PR TITLE
Windows newline support (CR+LF, \r\n)

### DIFF
--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -68,6 +68,10 @@ exports.tokenize = function (str) {
   var token, captures, ignore, input,
       indents = 0, lastIndents = 0,
       stack = [], indentAmount = -1
+
+  // Windows new line support (CR+LF, \r\n)
+  str = str.replace(/\r\n/g, "\n");
+
   while (str.length) {
     for (var i = 0, len = tokens.length; i < len; ++i)
       if (captures = tokens[i][1].exec(str)) {


### PR DESCRIPTION
I've added support for windows newline `\r\n` character. On my setup (Windows XP, node v0.8.1) when I tried to execute `yaml.eval()` on file that had `\r\n` the application hanged with 100% CPU usage. This fixed the problem.
