### PR TITLE
Support keys starting with slash

### DIFF
--- a/examples/hash.yml
+++ b/examples/hash.yml
@@ -13,6 +13,8 @@
     website: http://en.wikipedia.org/wiki/Austria
   space:
     description: space, the final frontier
+  /path:
+    description: this is a path
   brackets:
     square: Square [brackets] can go in the middle of strings
     squiggle: Squiggle {brackets} can also go in the middle of strings!

--- a/lib/yaml.js
+++ b/lib/yaml.js
@@ -52,8 +52,8 @@ var tokens = [
   [']', /^\]/],
   ['-', /^\-/],
   [':', /^[:]/],
-  ['string', /^(?![^:\n\s]*:[^\/]{2})(([^:,\]\}\n\s]|(?!\n)\s(?!\s*?\n)|:\/\/|,(?=[^\n]*\s*[^\]\}\s\n]\s*\n)|[\]\}](?=[^\n]*\s*[^\]\}\s\n]\s*\n))*)(?=[,:\]\}\s\n]|$)/], 
-  ['id', /^([\w][\w -]*)/]
+  ['string', /^(?![^:\n\s]*:[^\/]{2})(([^:,\]\}\n\s]|(?!\n)\s(?!\s*?\n)|:\/\/|,(?=[^\n]*\s*[^\]\}\s\n]\s*\n)|[\]\}](?=[^\n]*\s*[^\]\}\s\n]\s*\n))*)(?=[,:\]\}\s\n]|$)/],
+  ['id', /^([\w|\/][\w -]*)/ ]
 ]
 
 /**
@@ -82,7 +82,7 @@ exports.tokenize = function (str) {
             ignore = true
             break
           case 'indent':
-            lastIndents = indents 
+            lastIndents = indents
             // determine the indentation amount from the first indent
             if (indentAmount == -1) {
               indentAmount = token[1][1].length
@@ -107,7 +107,7 @@ exports.tokenize = function (str) {
       if (token)
         stack.push(token),
         token = null
-      else 
+      else
         throw new SyntaxError(context(str))
     ignore = false
   }
@@ -364,7 +364,7 @@ Parser.prototype.parseTimestamp = function() {
   var year = token[2]
     , month = token[3]
     , day = token[4]
-    , hour = token[5] || 0 
+    , hour = token[5] || 0
     , min = token[6] || 0
     , sec = token[7] || 0
 


### PR DESCRIPTION
We use YAML for API description and there are a lot of cases that keys start with a leading slash where keys are basically HTTP paths. This will allow such keys to work
