### PR TITLE
Adding license attribute to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,7 @@
   "version": "0.2.3",
   "description": "Yaml parser",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
-  "main": "./lib/yaml.js"
+  "main": "./lib/yaml.js",
+  "repository": "tj/js-yaml",
+  "license": "MIT"
 }


### PR DESCRIPTION
https://docs.npmjs.com/files/package.json#license
http://npm1k.org/

Also added `repository` so you can find this module via npmjs.org